### PR TITLE
increase API usability

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,15 @@ html_theme_options = {
 }
 html_title = f"{project} {version}"
 
-autodoc_default_options = {"ignore-module-all": True}
+exclude_members = (
+    "_asdict, _fields, _field_defaults, _make, _replace, "  # ignore some common members from NamedTuples.
+    + "__get_pygeom_active_detector, __set_pygeom_active_detector, _KeyboardInteractor"  # ...and some internal of ours.
+)
+
+autodoc_default_options = {
+    "ignore-module-all": True,
+    "exclude-members": exclude_members,
+}
 
 # sphinx-napoleon
 # enforce consistent usage of NumPy-style docstrings

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -46,7 +46,7 @@ For application developers (general setup)
 
 .. code:: python
 
-    from pygeomtools import detectors, geometry, visualization
+    from pygeomtools import detectors, geometry, visualization, write_pygeom
 
     reg = geant4.Registry()
 
@@ -54,11 +54,9 @@ For application developers (general setup)
     # include some of the things described above (detectors, coloring)
     # ...
 
-    detectors.write_detector_auxvals(reg)
-    visualization.write_color_auxvals(reg)
-    geometry.check_registry_sanity(reg, reg)
-
-    # now write out the GDML or visualize it.
+    # commit all auxiliary data to the registry and write out the GDML file. Use None as
+    # file name to suppress writing a file (e.g. when you only want to visualize)
+    write_pygeom(reg, "test.gdml")
 
 
 Table of Contents

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,9 @@ For geometry writers
 --------------------
 
 If your geometry creation script/notebook/application is already set up correctly, you
-can use the following set of attributes to control the package's output.
+can use our :doc:`extensions to the pyg4ometry API <pyg4-api>` to control the package's output.
+
+Detector registration and visualization attributes will be stored into the output GDML file.
 
 Registering detectors for use with `remage`_
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -19,10 +21,12 @@ On a physical volume instance, you can attach a ``pygeom_active_detector``, e.g.
    pv = g4.PhysicalVolume(...)
 
    # attach an active detector to this physical volume.
-   pv.pygeom_active_detector = RemageDetectorInfo(
-       "optical",  # detector type. The available options are defined by remage.
-       1,  # detector id in remage.
-       {"some": "metadata"},  # user-defined data (optional) that is stored into GDML.
+   pv.set_pygeom_active_detector(
+       RemageDetectorInfo(
+           "optical",  # detector type. The available options are defined by remage.
+           1,  # detector id in remage.
+           {"some": "metadata"},  # user-defined data (optional) that is stored into GDML.
+       )
    )
 
 
@@ -68,5 +72,6 @@ Table of Contents
    Metadata in GDML <metadata>
    GDML viewer <vis>
    Package API reference <api/modules>
+   pyg4ometry API extensions <pyg4-api>
 
 .. _remage: https://github.com/legend-exp/remage

--- a/docs/source/pyg4-api.rst
+++ b/docs/source/pyg4-api.rst
@@ -1,0 +1,48 @@
+pyg4ometry API extensions
+=========================
+
+Detector registration
+---------------------
+
+.. py:class:: pyg4ometry.geant4.PhysicalVolume
+
+    .. py:method:: set_pygeom_active_detector(det_info)
+
+       :param det_info:
+       :type det_info: RemageDetectorInfo
+
+       Set the remage detector info on this physical volume instance.
+
+    .. py:method:: get_pygeom_active_detector()
+
+       :rtype: RemageDetectorInfo | None
+
+       Get the remage detector info on this physical volume instance.
+
+    .. py:attribute:: pygeom_active_detector
+
+        :type: RemageDetectorInfo
+        :value: (initially not set)
+        :deprecated: use :meth:`set_pygeom_active_detector`/:meth:`get_pygeom_active_detector` instead
+
+        get or set the active detector instance.
+
+        .. warning::
+
+            will raise an :class:`AttributeError` if trying to access without setting first.
+
+Visualization
+-------------
+
+.. py:class:: pyg4ometry.geant4.LogicalVolume
+
+    .. py:attribute:: pygeom_color_rgba
+
+        :type: False | tuple[float, float, float, float]
+        :value: (initially not set)
+
+        ``False`` (hidden) or a RGBA color tuple (range 0-1)
+
+        .. warning::
+
+            will raise an :class:`AttributeError` if trying to access without setting first.

--- a/src/pygeomtools/__init__.py
+++ b/src/pygeomtools/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-# note: do not load viewer module here, as it has quite large nested imports.
-from . import detectors, geometry, utils
+# note: do not load viewer module here, as it has quite large nested imports. see lazy loading below.
+from . import detectors, geometry, utils, visualization
 from ._version import version as __version__
 from .detectors import RemageDetectorInfo, get_all_sensvols, get_sensvol_metadata
 from .write import write_pygeom
@@ -14,5 +14,6 @@ __all__ = [
     "get_all_sensvols",
     "get_sensvol_metadata",
     "utils",
+    "visualization",
     "write_pygeom",
 ]

--- a/src/pygeomtools/__init__.py
+++ b/src/pygeomtools/__init__.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+# note: do not load viewer module here, as it has quite large nested imports.
 from . import detectors, geometry, utils
 from ._version import version as __version__
 from .detectors import RemageDetectorInfo, get_all_sensvols, get_sensvol_metadata
-
-# note: do not load viewer module here, as it has quite large nested imports.
+from .write import write_pygeom
 
 __all__ = [
     "RemageDetectorInfo",
@@ -14,4 +14,5 @@ __all__ = [
     "get_all_sensvols",
     "get_sensvol_metadata",
     "utils",
+    "write_pygeom",
 ]

--- a/src/pygeomtools/detectors.py
+++ b/src/pygeomtools/detectors.py
@@ -156,3 +156,26 @@ def get_all_sensvols(registry: g4.Registry) -> dict[str, RemageDetectorInfo]:
         raise RuntimeError(msg)
 
     return detmapping
+
+
+def __set_pygeom_active_detector(self, det_info: RemageDetectorInfo | None) -> None:
+    """Set the remage detector info on this physical volume instance."""
+    if not isinstance(self, g4.PhysicalVolume):
+        msg = "patched-in function called on wrong type"
+        raise TypeError(msg)
+    self.pygeom_active_detector = det_info
+
+
+def __get_pygeom_active_detector(self) -> RemageDetectorInfo | None:
+    """Get the remage detector info on this physical volume instance."""
+    if not isinstance(self, g4.PhysicalVolume):
+        msg = "patched-in function called on wrong type"
+        raise TypeError(msg)
+    if hasattr(self, "pygeom_active_detector"):
+        return self.pygeom_active_detector
+    return None
+
+
+# monkey-patch a new function onto every PhysicalVolume instance:
+g4.PhysicalVolume.set_pygeom_active_detector = __set_pygeom_active_detector
+g4.PhysicalVolume.get_pygeom_active_detector = __get_pygeom_active_detector

--- a/src/pygeomtools/viewer.py
+++ b/src/pygeomtools/viewer.py
@@ -239,7 +239,10 @@ def _color_recursive(
     lv: g4.LogicalVolume, viewer: pyg4vis.ViewerBase, overrides: dict
 ) -> None:
     if hasattr(lv, "pygeom_color_rgba") or lv.name in overrides:
-        color_rgba = overrides.get(lv.name, lv.pygeom_color_rgba)
+        color_rgba = lv.pygeom_color_rgba if hasattr(lv, "pygeom_color_rgba") else None
+        color_rgba = overrides.get(lv.name, color_rgba)
+        assert color_rgba is not None
+
         for vis in viewer.instanceVisOptions[lv.name]:
             if color_rgba is False:
                 vis.alpha = 0

--- a/src/pygeomtools/write.py
+++ b/src/pygeomtools/write.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+
+from pyg4ometry import gdml, geant4
+
+from . import detectors, geometry, visualization
+
+
+def write_pygeom(
+    reg: geant4.Registry,
+    gdml_file: str | os.PathLike | None = None,
+    write_vis_auxvals: bool = True,
+) -> None:
+    """Commit all auxiliary data to the registry and write out a GDML file."""
+    detectors.write_detector_auxvals(reg)
+    if write_vis_auxvals:
+        visualization.write_color_auxvals(reg)
+    geometry.check_registry_sanity(reg, reg)
+
+    if gdml_file is not None:
+        # pyg4ometry has added color writing in their bdsim style by default in 2025.
+        try:
+            w = gdml.Writer(writeColour=False)
+        except TypeError:
+            w = gdml.Writer()
+
+        w.addDetector(reg)
+        w.write(str(gdml_file))

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -14,7 +14,7 @@ def test_package():
 
 
 def test_detector_info(tmp_path):
-    from pygeomtools import RemageDetectorInfo, detectors, geometry, visualization
+    from pygeomtools import RemageDetectorInfo, detectors, write_pygeom
 
     registry = g4.Registry()
     world = g4.solid.Box("world", 2, 2, 2, registry, "m")
@@ -48,14 +48,7 @@ def test_detector_info(tmp_path):
         "germanium", 2, {"other": "other metadata"}
     )
 
-    detectors.write_detector_auxvals(registry)
-    visualization.write_color_auxvals(registry)
-    geometry.check_registry_sanity(registry, registry)
-
-    w = pyg4ometry.gdml.Writer()
-    w.addDetector(registry)
-
-    w.write(tmp_path / "geometry.gdml")
+    write_pygeom(registry, tmp_path / "geometry.gdml")
 
     # test read again
     registry = pyg4ometry.gdml.Reader(tmp_path / "geometry.gdml").getRegistry()

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -33,11 +33,14 @@ def test_detector_info(tmp_path):
     scint1pv = g4.PhysicalVolume(
         [0, 0, 0], [-255, 0, 0], scint1, "scint1", world_lv, registry
     )
-    scint1pv.pygeom_active_detector = RemageDetectorInfo("scintillator", 3)
+    scint1pv.set_pygeom_active_detector(RemageDetectorInfo("scintillator", 3))
     scint2pv = g4.PhysicalVolume(
         [0, 0, 0], [+255, 0, 0], scint2, "scint2", world_lv, registry
     )
-    scint2pv.pygeom_active_detector = RemageDetectorInfo("scintillator", 3)
+    assert scint2pv.get_pygeom_active_detector() is None
+    scint2pv.set_pygeom_active_detector(RemageDetectorInfo("scintillator", 3))
+    assert scint2pv.pygeom_active_detector is not None
+    assert scint2pv.get_pygeom_active_detector() == scint2pv.pygeom_active_detector
 
     det = g4.solid.Box("det", 0.1, 0.5, 0.5, registry, "m")
     det = g4.LogicalVolume(det, g4.MaterialPredefined("G4_Ge"), "det", registry)


### PR DESCRIPTION
* add a `write_pygeom()` wrapper that calls all other of our functions that need to be called
* add getter/setter functions for `pygeom_active_detector`, to solve potential silent problems from mistyping that attribute name.