### PR TITLE
Fix headless PNG export segfault on EGL-only VTK builds

### DIFF
--- a/src/pygeomtools/viewer.py
+++ b/src/pygeomtools/viewer.py
@@ -40,10 +40,28 @@ def visualize(registry: g4.Registry, scenes: dict | None = None, points=None) ->
     if scenes is None:
         scenes = {}
 
+    # if this option is set, do not use the interactor style (interactive=False below),
+    # and directly trigger an export below.
+    export_and_exit = scenes.get("export_and_exit")
+
+    if export_and_exit:
+        # force headless (offscreen) rendering. this has to happen _before_ the render
+        # window is created, so the graphics factory picks an offscreen-capable window
+        # class (EGL or OSMesa, depending on the VTK build). do not force Mesa classes:
+        # they do not exist on EGL-only builds (e.g. the PyPI vtk wheels) and cause a
+        # segfault.
+        vtk.vtkGraphicsFactory().SetOffScreenOnlyMode(1)
+
     try:
         v = pyg4vis.VtkViewerColouredNew(defaultCutters=False, axisCubeWidget=False)
     except TypeError:
         v = pyg4vis.VtkViewerColouredNew()
+
+    if export_and_exit:
+        # enable offscreen rendering before any Render() call happens (e.g. via
+        # _set_camera_scene below), otherwise the render hits the X server and segfaults
+        # on headless machines.
+        v.renWin.SetOffScreenRendering(1)
 
     if scenes.get("export_transparent", False):
         v.renWin.SetAlphaBitPlanes(1)  # enable alpha channel
@@ -127,10 +145,6 @@ def visualize(registry: g4.Registry, scenes: dict | None = None, points=None) ->
             v, light_pos=light.get("pos"), shadow=light.get("shadow", True)
         )
 
-    # if this option is set, do not use the interactor style (interactive=False below),
-    # and directly trigger an export below.
-    export_and_exit = scenes.get("export_and_exit")
-
     if not export_and_exit:
         # override the interactor style.
         v.interactorStyle = _KeyboardInteractor(v.ren, v.iren, v, scenes)
@@ -142,14 +156,6 @@ def visualize(registry: g4.Registry, scenes: dict | None = None, points=None) ->
 
     if "window_size" in scenes:
         v.renWin.SetSize(*scenes["window_size"])
-
-    if export_and_exit:
-        # force a headless mode.
-        graphics_factory = vtk.vtkGraphicsFactory()
-        graphics_factory.SetOffScreenOnlyMode(1)
-        graphics_factory.SetUseMesaClasses(1)
-
-        v.renWin.SetOffScreenRendering(1)
 
     v.view(interactive=export_and_exit is None)
 

--- a/tests/test_viewer.py
+++ b/tests/test_viewer.py
@@ -5,10 +5,27 @@ from pathlib import Path
 
 import lh5
 import pytest
+import vtk
 from lgdo import Array, Table, VectorOfVectors
 from pyg4ometry import gdml
 
 from pygeomtools import viewer
+
+
+def _offscreen_gl_available() -> bool:
+    """Return True if the VTK build can render offscreen (EGL or OSMesa)."""
+    try:
+        vtk.vtkGraphicsFactory().SetOffScreenOnlyMode(1)
+        ren_win = vtk.vtkRenderWindow()
+        ren_win.SetOffScreenRendering(1)
+        ren_win.AddRenderer(vtk.vtkRenderer())
+        ren_win.SetSize(16, 16)
+        ren_win.Render()
+        ok = bool(ren_win.GetOffScreenRendering())
+        ren_win.Finalize()
+        return ok
+    except Exception:
+        return False
 
 
 @pytest.fixture
@@ -27,6 +44,35 @@ def points_file(tmp_path):
     lh5.write(tab, "stp/test", file, wo_mode="of")
 
     return str(file)
+
+
+@pytest.mark.skipif(
+    not _offscreen_gl_available(),
+    reason="no offscreen GL backend (EGL/OSMesa) available",
+)
+def test_viewer_headless_export(tmp_path):
+    """Smoke test for the headless PNG export path on EGL-only VTK builds."""
+    registry = gdml.Reader(Path(__file__).parent / "geometry.gdml").getRegistry()
+
+    output_file = tmp_path / "headless.png"
+    output_file.unlink(missing_ok=True)
+
+    viewer.visualize(
+        registry,
+        {
+            "window_size": [200, 300],
+            "export_and_exit": output_file,
+            "default": {
+                "up": [0, 0, 1],
+                "camera": [-2000, 2000, 2000],
+                "focus": [0, 0, 0],
+                "parallel": False,
+            },
+        },
+    )
+
+    assert output_file.exists()
+    assert output_file.stat().st_size > 0
 
 
 def test_viewer(tmp_path, points_file):


### PR DESCRIPTION
## Problem

The headless PNG export path in `visualize()` (`export_and_exit`, also reached via `legend-pygeom-l200 --visualize` and `legend-pygeom-vis`) **segfaults** on VTK builds that provide the **EGL** render-window backend but not OSMesa, e.g. the PyPI `vtk` wheels (tested VTK 9.6.2). It works on conda-forge VTK (9.6.1), which ships OSMesa.

Symptom just before the crash:
```
vtkXOpenGLRenderWindow ... WARN| bad X server connection. DISPLAY=:0
```
followed by a core dump (no Python traceback).

## Root causes (all in `visualize()`)

1. `graphics_factory.SetUseMesaClasses(1)` forced the factory to instantiate Mesa/OSMesa classes. On an EGL-only build those classes don't exist, so it fell back to an X window / null and later crashed.
2. Offscreen rendering was enabled too late: `_set_camera_scene(v, ...)` already calls `Render()` on the still-on-screen window, which hits the X server and segfaults headless.
3. `SetOffScreenOnlyMode(1)` ran *after* the render window was already created, so it could not influence which window class the factory picked.

## Fix

- Read `export_and_exit` at the top of `visualize()`.
- Call `vtk.vtkGraphicsFactory().SetOffScreenOnlyMode(1)` **before** the render window is created, so the factory picks an offscreen-capable class (EGL or OSMesa, whichever the build has).
- Call `v.renWin.SetOffScreenRendering(1)` **immediately after** the viewer is created, before any `Render()`.
- Drop `SetUseMesaClasses(1)` and the old late headless block.

Backward-compatible with OSMesa builds; additionally fixes EGL-only builds.

## Tests

Adds `test_viewer_headless_export`: builds the geometry, runs the headless export, and asserts a non-empty PNG. Guarded by `skipif` using a minimal offscreen-render probe, so it skips cleanly when no EGL/OSMesa backend is available.

Verified locally: all viewer tests pass, ruff/pre-commit clean.